### PR TITLE
Adding the possibility to enable only listeners or senders

### DIFF
--- a/src/Testing/CoreTests/Runtime/Routing/routing_precedence.cs
+++ b/src/Testing/CoreTests/Runtime/Routing/routing_precedence.cs
@@ -221,15 +221,41 @@ public class FakeRoutingConvention : IMessageRoutingConvention
 
     public void DiscoverListeners(IWolverineRuntime runtime, IReadOnlyList<Type> handledMessageTypes)
     {
+        if (_onlyApplyToOutboundMessages)
+        {
+            return;
+        }
+        
         // Nothing
     }
 
     public IEnumerable<Endpoint> DiscoverSenders(Type messageType, IWolverineRuntime runtime)
     {
+        if (_onlyApplyToInboundMessages)
+        {
+            yield break;
+        }
+        
         if (Senders.TryGetValue(messageType, out var port))
         {
             var endpoint = runtime.Endpoints.GetOrBuildSendingAgent(new Uri("tcp://localhost:" + port)).Endpoint;
             yield return endpoint;
         }
+    }
+
+    private bool _onlyApplyToOutboundMessages;
+    
+    public void OnlyApplyToOutboundMessages()
+    {
+        _onlyApplyToInboundMessages = false;
+        _onlyApplyToOutboundMessages = true;
+    }
+    
+    private bool _onlyApplyToInboundMessages;
+    
+    public void OnlyApplyToInboundMessages()
+    {
+        _onlyApplyToOutboundMessages = false;
+        _onlyApplyToInboundMessages = true;
     }
 }

--- a/src/Wolverine/Runtime/Routing/IMessageRoutingConvention.cs
+++ b/src/Wolverine/Runtime/Routing/IMessageRoutingConvention.cs
@@ -9,4 +9,6 @@ public interface IMessageRoutingConvention
 {
     void DiscoverListeners(IWolverineRuntime runtime, IReadOnlyList<Type> handledMessageTypes);
     IEnumerable<Endpoint> DiscoverSenders(Type messageType, IWolverineRuntime runtime);
+    void OnlyApplyToOutboundMessages();
+    void OnlyApplyToInboundMessages();
 }


### PR DESCRIPTION

Added OnlyApplyToOutboundMessages and OnlyApplyToInboundMessages methods to the MessageRoutingConvention and IMessageRoutingConvention.

OnlyApplyToOutboundMessages should disable the discovery of any listeners.

OnlyApplyToInboundMessages should disable the discovery of any senders.

Probably i messed something up if yes just comment on how to improve the code or fix the logic

Thanks for the awesome project and i am glad that i could help out even a tiny bit.